### PR TITLE
adding typeof check to prevent race conditions

### DIFF
--- a/flask_jsonpify.py
+++ b/flask_jsonpify.py
@@ -6,7 +6,7 @@ def __pad(strdata):
     nothing.
     """
     if request.args.get('callback'):
-        return "%s(%s);" % (request.args.get('callback'), strdata)
+        return "typeof {0} === 'function' && {0}({1});".format(request.args.get('callback'), strdata)
     else:
         return strdata
 


### PR DESCRIPTION
I noticed when a callback function is called when the interpreter hasn't yet gotten to that function's definition, a race condition ensues which leads to the following error:

![image](https://cloud.githubusercontent.com/assets/991121/7409392/e8d5834a-eeda-11e4-84de-aa497d638020.png)

I've added a simple check that the callback function is indeed a function (i.e. that its definition has already been processed), to avoid these errors. Hope this helps the library!